### PR TITLE
Edit cors settings

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,11 +7,11 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "localhost:3001" # Next.js 開発サーバ
+    origins "http://localhost:3000"  # Next.js の開発サーバ
     resource "*",
       headers: :any,
       expose: [ "Authorization" ],
-      methods: [ :get, :post, :options ],
+      methods: [ :get, :post, :delete, :options ],
       credentials: true
   end
 end


### PR DESCRIPTION
ポート番号を3000に変更
下記質問ログ


---
---

このポート番号の違いは、**「どちらをフロントエンド（Next.js）側として動かしているか」**によって変わります。

---

### 🔍 現状の整理

| サーバ | 役割 | ポート |
|--------|------|--------|
| Rails | APIサーバ | **3001** |
| Next.js | フロントエンド（開発サーバ） | **3000** |

---

### ✅ 今回の構成
Next.js が `npm run dev` で起動 → ポート **3000**
Rails が API として動作 → ポート **3001**

したがって、Rails 側から見ると **「フロントエンドは http://localhost:3000」** がアクセス元になります。  
そのため、CORS設定の `origins` は：

```ruby
origins "http://localhost:3000"
```

が正解です。

---

### 💡 一方、以前の設定（`localhost:3001`）は…

その逆（＝Railsが3000番、Next.jsが3001番）で動かしていた時期の構成です。  
つまり、  
- Rails：3000  
- Next.js：3001  
という環境では、CORS側に `"localhost:3001"` を書く必要がありました。

---

### ✅ まとめ

| 状況 | 設定すべき `origins` |
|------|------------------------|
| Railsが3000番, Next.jsが3001番 | `"http://localhost:3001"` |
| Railsが3001番, Next.jsが3000番（現在） | `"http://localhost:3000"` |

---

要するに：
> 「**Next.jsのポート番号**」＝ `origins` に書く値  

です。  
今の構成（Rails:3001 / Next.js:3000）であれば、現行の設定で正解です ✅